### PR TITLE
Implement basic escape analysis within XCompiler

### DIFF
--- a/src/escape_analysis.jl
+++ b/src/escape_analysis.jl
@@ -85,6 +85,9 @@ function escape_analysis(ir::IRCode, ci::CodeInfo)
                 ssa_val = inst.val
                 escaped = EscapedVal(TYP_SSA, ssa_val.id)
                 update_escapes!(escapes, escaped, idx)
+            elseif isa(inst, Argument)
+                escaped = EscapedVal(TYP_ARG, inst.n)
+                update_escapes!(escapes, escaped, idx)
             end
         end
     end

--- a/src/escape_analysis.jl
+++ b/src/escape_analysis.jl
@@ -1,22 +1,55 @@
-using Core: ReturnNode, SSAValue
+using Core: ReturnNode, SSAValue, Argument
+using Base: length, hash
+
+const TYP_SSA = 1
+const TYP_ARG = 2
+
+struct EscapedVal
+    type::Int # 1 for SSAValue, 2 for Argument
+    val::Int
+end
+
+Base.hash(x::EscapedVal) = Base.hash(x.type, Base.hash(x.val))
+
+function update_escapes!(escapes::Dict{EscapedVal, Set{Int}}, escaped::EscapedVal, escape_id::Int)
+    if !haskey(escapes, escaped)
+        escapes[escaped] = Set()
+    end
+    union(escapes[escaped], escape_id)
+end
 
 function escape_analysis(ir::IRCode, ci::CodeInfo)
+    @show ir
     # TODO: at this moment, let's assume the function only has a
     # single giant BaiscBlock
-    # a mapping from stmt idx to a set of escape values (represented by idx) at this stmt
-    escapes = Dict{Int, Set{Int}}()
-    for (idx, inst) in Iterators.reverse(enumerate(ir.stmts))
-        stmt = inst[:inst]
-        if idx in escapes
-            if isa(stmt, Expr)
-                union!(escapes[idx])
+
+    # a mapping from stmt idx to its most recent escape site
+    escapes = Dict{EscapedVal, Set{Int}}()
+    len = length(ir.stmts)
+    for idx in len:-1:1
+        stmt = ir.stmts[idx]
+        inst = stmt[:inst]
+        # if the current stmt is already escaped
+        # mark each of its arg as escaped from this
+        if idx in keys(escapes)
+            if isa(inst, Expr)
+                for arg in inst.args[2:end]
+                    if isa(arg, Argument)
+                        escaped = EscapedVal(TYP_ARG, arg.n)
+                        update_escapes!(escapes, escaped, idx)
+                    elseif isa(arg, SSAValue)
+                        escaped = EscapedVal(TYP_SSA, arg.id)
+                        update_escapes!(escapes, escaped, idx)
+                    end
+                end
             end
         end
-        if isa(stmt, ReturnNode) && isdefined(stmt, :val)
-            escapes[idx] = Set()
-            if isa(stmt.val, SSAValue)
-                ssa_val = stmt.val
-                union!(escapes[ssa_val.val], [idx])
+        if isa(inst, ReturnNode) && isdefined(inst, :val)
+            if isa(inst.val, SSAValue)
+                ssa_val = inst.val
+                escaped = EscapedVal(TYP_SSA, ssa_val.id)
+                update_escapes!(escapes, escaped, idx)
+            end
         end
     end
     return ir

--- a/src/escape_analysis.jl
+++ b/src/escape_analysis.jl
@@ -1,3 +1,15 @@
+using Core: ReturnNode
+
 function escape_analysis(ir::IRCode, ci::CodeInfo)
+    # TODO: at this moment, let's assume the function only has a
+    # single giant BaiscBlock
+    # a mapping from stmt idx to a set of escape values (represented by idx) at this stmt
+    escapes = Dict{Int, Set{Int}}()
+    for (idx, inst) in Iterators.reverse(enumerate(ir.stmts))
+        stmt = inst[:inst]
+        if isa(stmt, ReturnNode)
+            nothing
+        end
+    end
     return ir
 end

--- a/src/escape_analysis.jl
+++ b/src/escape_analysis.jl
@@ -1,3 +1,23 @@
+using Core: ReturnNode, SSAValue
+
 function escape_analysis(ir::IRCode, ci::CodeInfo)
+    # TODO: at this moment, let's assume the function only has a
+    # single giant BaiscBlock
+    # a mapping from stmt idx to a set of escape values (represented by idx) at this stmt
+    escapes = Dict{Int, Set{Int}}()
+    for (idx, inst) in Iterators.reverse(enumerate(ir.stmts))
+        stmt = inst[:inst]
+        if idx in escapes
+            if isa(stmt, Expr)
+                union!(escapes[idx])
+            end
+        end
+        if isa(stmt, ReturnNode) && isdefined(stmt, :val)
+            escapes[idx] = Set()
+            if isa(stmt.val, SSAValue)
+                ssa_val = stmt.val
+                union!(escapes[ssa_val.val], [idx])
+        end
+    end
     return ir
 end

--- a/src/escape_analysis.jl
+++ b/src/escape_analysis.jl
@@ -87,8 +87,11 @@ function escape_analysis(ir::IRCode, ci::CodeInfo)
     escaped_args = Vector{Int}()
     for idx in 2:(1 + args_len)
         if in_escapes(escapes, TYP_ARG, idx)
-            @printf("Arg %d escaped!\n", idx)
-            push!(escaped_args, idx)
+            # only consider mutable type
+            if ismutabletype(ir.argtypes[idx])
+                @printf("Mutable arg %d escaped!\n", idx)
+                push!(escaped_args, idx)
+            end
         end
     end
     # and find out if any allocations are escaped

--- a/src/escape_analysis.jl
+++ b/src/escape_analysis.jl
@@ -1,0 +1,3 @@
+function escape_analysis(ir::IRCode, ci::CodeInfo)
+    return ir
+end

--- a/src/escape_analysis.jl
+++ b/src/escape_analysis.jl
@@ -1,5 +1,6 @@
 using Core: ReturnNode, SSAValue, Argument
 using Base: length, hash
+using Printf
 
 const TYP_SSA = 1
 const TYP_ARG = 2
@@ -15,7 +16,17 @@ function update_escapes!(escapes::Dict{EscapedVal, Set{Int}}, escaped::EscapedVa
     if !haskey(escapes, escaped)
         escapes[escaped] = Set()
     end
+    @printf("Escaped! %s %d => Stmt %d\n", escaped.type == 1 ? "SSAValue" : "Argument", escaped.val, escape_id)
     union!(escapes[escaped], escape_id)
+end
+
+function in_escapes(escapes::Dict{EscapedVal, Set{Int}}, idx::Int)
+    for k in keys(escapes)
+        if k.type == 1 && k.val == idx
+            return true
+        end
+    end
+    return false
 end
 
 function escape_analysis(ir::IRCode, ci::CodeInfo)
@@ -31,7 +42,7 @@ function escape_analysis(ir::IRCode, ci::CodeInfo)
         inst = stmt[:inst]
         # if the current stmt is already escaped
         # mark each of its arg as escaped from this
-        if idx in keys(escapes)
+        if in_escapes(escapes, idx)
             if isa(inst, Expr)
                 for arg in inst.args[2:end]
                     if isa(arg, Argument)

--- a/src/escape_analysis.jl
+++ b/src/escape_analysis.jl
@@ -15,7 +15,7 @@ function update_escapes!(escapes::Dict{EscapedVal, Set{Int}}, escaped::EscapedVa
     if !haskey(escapes, escaped)
         escapes[escaped] = Set()
     end
-    union(escapes[escaped], escape_id)
+    union!(escapes[escaped], escape_id)
 end
 
 function escape_analysis(ir::IRCode, ci::CodeInfo)
@@ -23,7 +23,7 @@ function escape_analysis(ir::IRCode, ci::CodeInfo)
     # TODO: at this moment, let's assume the function only has a
     # single giant BaiscBlock
 
-    # a mapping from stmt idx to its most recent escape site
+    # a mapping from escaped value to its most recent escape site (idx)
     escapes = Dict{EscapedVal, Set{Int}}()
     len = length(ir.stmts)
     for idx in len:-1:1

--- a/src/optimize.jl
+++ b/src/optimize.jl
@@ -25,7 +25,39 @@ function CC.finish(interp::XInterpreter, opt::OptimizationState, params::Optimiz
 end
 
 function CC.optimize(interp::XInterpreter, opt::OptimizationState, params::OptimizationParams, @nospecialize(result))
-    ret = @invoke optimize(interp::AbstractInterpreter, opt::OptimizationState, params::OptimizationParams, @nospecialize(result))
+    nargs = Int(opt.args) - 1
+    ir = x_run_passes(opt.src, nargs, opt)
+    return finish(interp, opt, params, ir, result)
+end
 
-    return ret
+include("escape_analysis.jl")
+
+function x_run_passes end
+let f() = @eval CC function $(XCompiler).x_run_passes(ci::CodeInfo, nargs::Int, sv::OptimizationState)
+    preserve_coverage = coverage_enabled(sv.mod)
+    ir = convert_to_ircode(ci, copy_exprargs(ci.code), preserve_coverage, nargs, sv)
+    ir = slot2reg(ir, ci, nargs, sv)
+    #@Base.show ("after_construct", ir)
+    ir = $(escape_analysis)(ir, ci)
+    # TODO: Domsorting can produce an updated domtree - no need to recompute here
+    @timeit "compact 1" ir = compact!(ir)
+    @timeit "Inlining" ir = ssa_inlining_pass!(ir, ir.linetable, sv.inlining, ci.propagate_inbounds)
+    #@timeit "verify 2" verify_ir(ir)
+    ir = compact!(ir)
+    #@Base.show ("before_sroa", ir)
+    @timeit "SROA" ir = getfield_elim_pass!(ir)
+    #@Base.show ir.new_nodes
+    #@Base.show ("after_sroa", ir)
+    ir = adce_pass!(ir)
+    #@Base.show ("after_adce", ir)
+    @timeit "type lift" ir = type_lift_pass!(ir)
+    @timeit "compact 3" ir = compact!(ir)
+    #@Base.show ir
+    if JLOptions().debug_level == 2
+        @timeit "verify 3" (verify_ir(ir); verify_linetable(ir.linetable))
+    end
+    return ir
+end
+
+push!(__init_hooks__, f)
 end

--- a/src/optimize.jl
+++ b/src/optimize.jl
@@ -40,7 +40,7 @@ let f() = @eval CC function $(XCompiler).x_run_passes(ci::CodeInfo, nargs::Int, 
     ir = convert_to_ircode(ci, copy_exprargs(ci.code), preserve_coverage, nargs, sv)
     ir = slot2reg(ir, ci, nargs, sv)
     #@Base.show ("after_construct", ir)
-    ir = $(escape_analysis)(ir, ci)
+    escape_info = $(escape_analysis)(ir, ci)
     # TODO: Domsorting can produce an updated domtree - no need to recompute here
     @timeit "compact 1" ir = compact!(ir)
     @timeit "Inlining" ir = ssa_inlining_pass!(ir, ir.linetable, sv.inlining, ci.propagate_inbounds)

--- a/src/optimize.jl
+++ b/src/optimize.jl
@@ -1,3 +1,5 @@
+# import Base: Base, @show
+
 function CC.OptimizationState(frame::InferenceState, params::OptimizationParams, interp::XInterpreter)
     ret = @invoke OptimizationState(frame::InferenceState, params::OptimizationParams, interp::AbstractInterpreter)
 
@@ -25,7 +27,7 @@ function CC.finish(interp::XInterpreter, opt::OptimizationState, params::Optimiz
 end
 
 function CC.optimize(interp::XInterpreter, opt::OptimizationState, params::OptimizationParams, @nospecialize(result))
-    nargs = Int(opt.args) - 1
+    nargs = Int(opt.nargs) - 1
     ir = x_run_passes(opt.src, nargs, opt)
     return finish(interp, opt, params, ir, result)
 end


### PR DESCRIPTION
This PR implements basic escape analysis within the XCompiler framework.

what's missing?
- [ ] handle different code paths
- [x] produce a scope-level escape summary.
- [ ] IPO